### PR TITLE
Rebuild gohai reliably

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -9,7 +9,7 @@ default['dd-agent-builder']['omnibus-software_branch'] = 'master'
 default['dd-agent-builder']['omnibus-ruby_branch'] = 'master'
 default['dd-agent-builder']['dd-integrations-core_branch'] = 'master'
 
-default['dd-agent-builder']['go']['version'] = '1.7.5'
+default['dd-agent-builder']['go']['version'] = '1.6.4'
 # Values are 386 or amd64
 default['dd-agent-builder']['go']['platform'] = 'amd64'
 default['dd-agent-builder']['go']['gopath'] = "#{ENV['HOME']}\\go"

--- a/recipes/build.rb
+++ b/recipes/build.rb
@@ -23,6 +23,13 @@ directory "#{dd_agent_omnibus_dir}/.bundle" do
   recursive true
 end
 
+# delete Gohai cache (otherwise build fails)
+# DELETE ME WHEN CENTOS 5 IS EOL
+directory 'C:\omnibus-ruby\cache\src' do
+  action :delete
+  recursive true
+end
+
 # Sync the repositories
 git dd_agent_omnibus_dir do
   repository 'https://github.com/DataDog/dd-agent-omnibus'


### PR DESCRIPTION
Gohai build always fails because of `go get`. We cannot get rid of it
before CentOS 5 is EOL, so we use this in the meantime.