### PR TITLE
[gitlab] Allow configuration to be passed via env

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,7 +8,7 @@ dd-agent:
   tags:
     - windows-builder
   script:
-    - chef-client -j c:\cfg\attributes.json -zo dd-agent-builder::build -l info
+    - chef-client --local-mode -o dd-agent-builder::build -l info
   after_script:
     - mkdir pkg
     - copy c:\omnibus-ruby\pkg\*.msi pkg

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,11 +3,11 @@ default['omnibus']['build_user_group'] = 'omnibus_group'
 default['omnibus']['build_user_password'] = 'defaultwindowspassword'
 
 default['dd-agent-builder']['install_dir'] = 'C:\opt\datadog-agent'
-default['dd-agent-builder']['dd-agent_branch'] = 'master'
-default['dd-agent-builder']['dd-agent-omnibus_branch'] = 'master'
-default['dd-agent-builder']['omnibus-software_branch'] = 'master'
-default['dd-agent-builder']['omnibus-ruby_branch'] = 'master'
-default['dd-agent-builder']['dd-integrations-core_branch'] = 'master'
+default['dd-agent-builder']['dd-agent_branch'] = ENV['DD_AGENT_BRANCH'] || 'master'
+default['dd-agent-builder']['dd-agent-omnibus_branch'] = ENV['DD_AGENT_OMNIBUS_BRANCH'] || 'master'
+default['dd-agent-builder']['omnibus-software_branch'] = ENV['OMNIBUS_SOFTWARE_BRANCH'] || 'master'
+default['dd-agent-builder']['omnibus-ruby_branch'] = ENV['OMNIBUS_RUBY_BRANCH'] || 'datadog-5.5.0'
+default['dd-agent-builder']['dd-integrations-core_branch'] = ENV['INTEGRATIONS_CORE_BRANCH'] || 'master'
 
 default['dd-agent-builder']['go']['version'] = '1.6.4'
 # Values are 386 or amd64

--- a/recipes/build.rb
+++ b/recipes/build.rb
@@ -46,6 +46,7 @@ end
 omnibus_build 'datadog-agent' do
   project_dir dd_agent_omnibus_dir
   log_level :info
+  live_stream true
   install_dir node['dd-agent-builder']['install_dir']
   environment 'AGENT_BRANCH' => node['dd-agent-builder']['dd-agent_branch'],
               'OMNIBUS_RUBY_BRANCH' => node['dd-agent-builder']['omnibus-ruby_branch'],


### PR DESCRIPTION
C:\cfg\attributes.json worked with packer, but once the provisioning part is done we have no way of editing attributes.json.