### PR TITLE
Db/build branches

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,12 +3,17 @@ before_script:
   - call berks vendor
   - move berks-cookbooks cookbooks
   - echo done with berks
+  - rd /s/q c:\omnibus
+  - rd /s/q c:\omnibus-ruby
+  - rd /s/q c:\opt\datadog-agent
+
   
 dd-agent:
   tags:
     - windows-builder
   script:
-    - chef-client -j .\attributes.json --local-mode -o dd-agent-builder::build -l info
+    - call chef-client -j .\attributes.json --local-mode -o dd-agent-builder::prepare -l info
+    - call chef-client -j .\attributes.json --local-mode -o dd-agent-builder::build -l info
   after_script:
     - mkdir pkg
     - copy c:\omnibus-ruby\pkg\*.msi pkg

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,7 +8,7 @@ dd-agent:
   tags:
     - windows-builder
   script:
-    - chef-client --local-mode -o dd-agent-builder::build -l info
+    - chef-client -j .\attributes.json --local-mode -o dd-agent-builder::build -l info
   after_script:
     - mkdir pkg
     - copy c:\omnibus-ruby\pkg\*.msi pkg

--- a/attributes.json
+++ b/attributes.json
@@ -1,7 +1,12 @@
 {
   "dd-agent-builder": {
+    "dd-agent-omnibus_branch": "5.13.x",
+    "omnibus-software_branch": "5.13.x",
+    "dd-agent_branch": "5.13.x",
+    "integrations-core_branch": "5.13.x",
     "omnibus-ruby_branch": "datadog-5.5.0"
   },
   "omnibus": {
+     "build_user_password": "DDBuildR0cks!"
   }
 }

--- a/attributes.json
+++ b/attributes.json
@@ -3,6 +3,5 @@
     "omnibus-ruby_branch": "datadog-5.5.0"
   },
   "omnibus": {
-     "build_user_password": "DDBuildR0cks!"
   }
 }

--- a/attributes.json
+++ b/attributes.json
@@ -3,5 +3,6 @@
     "omnibus-ruby_branch": "datadog-5.5.0"
   },
   "omnibus": {
+     "build_user_password": "DDBuildR0cks!"
   }
 }

--- a/attributes.json
+++ b/attributes.json
@@ -1,0 +1,8 @@
+{
+  "dd-agent-builder": {
+    "omnibus-ruby_branch": "datadog-5.5.0"
+  },
+  "omnibus": {
+     "build_user_password": "DDBuildR0cks!"
+  }
+}

--- a/attributes.json
+++ b/attributes.json
@@ -1,10 +1,6 @@
 {
   "dd-agent-builder": {
-    "dd-agent-omnibus_branch": "5.13.x",
-    "omnibus-software_branch": "5.13.x",
-    "dd-agent_branch": "5.13.x",
-    "integrations-core_branch": "5.13.x",
-    "omnibus-ruby_branch": "datadog-5.5.0"
+      "omnibus-ruby_branch": "datadog-5.5.0"
   },
   "omnibus": {
      "build_user_password": "DDBuildR0cks!"

--- a/attributes.json
+++ b/attributes.json
@@ -3,6 +3,5 @@
       "omnibus-ruby_branch": "datadog-5.5.0"
   },
   "omnibus": {
-     "build_user_password": "DDBuildR0cks!"
   }
 }

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,6 +1,7 @@
 default['omnibus']['build_user'] = 'omnibus'
 default['omnibus']['build_user_group'] = 'omnibus_group'
-default['omnibus']['build_user_password'] = 'defaultwindowspassword'
+raise 'BUILD_USER_PASSWORD not set!' unless ENV['BUILD_USER_PASSWORD']
+default['omnibus']['build_user_password'] = "#{ENV['BUILD_USER_PASSWORD']}"
 
 default['dd-agent-builder']['install_dir'] = 'C:\opt\datadog-agent'
 default['dd-agent-builder']['dd-agent_branch'] = ENV['DD_AGENT_BRANCH'] || 'master'


### PR DESCRIPTION
Add ability to build specific branches of the other related repos on gitlab.
First change is to make sure to clear artifacts of previous builds.  This will make the builds take longer, but produces a more reliable result.

Second change is to source the "attributes.json" locally.  By default, it's using master for each repo.

However, each branch can be specified in "attributes.json", allowing for a single branch on the dd-agent-builder repo to define a combination of branches in the other repos.

Creating a dd-agent-builder branch, and changing attributes.json results in a build pipeline for the specified branches.