### PR TITLE
Pull the information from the release.json in dd-agent-omnibus instead of attribute.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,59 @@ Installs Golang and all the dependencies of Omnibus, and downloads `dd-agent-omn
 ## dd-agent-builder::build
 
 Builds the agent (with the omnibus_build resource from the omnibus cookbook).
+
+
+Setting custom parameters
+=========================
+
+Variables to build an agent are pulled from [release.json from
+dd-agent-omnibus](https://github.com/DataDog/dd-agent-omnibus/blob/master/release.json).
+Those variables are used to pin version of the agent dependencies.
+
+By default the job will use dd-agent-omnibus's `master` and `nightly` from `release.json`.
+
+## Pulling a specific version of dd-agent-omnibus
+
+You can choose a specific branch, tag or commit by setting the environment
+variable `DD_AGENT_OMNIBUS_BRANCH`.
+
+## Building a specific version of the agent
+
+Instead of building `nightly` you can choose a version from
+[release.json](https://github.com/DataDog/dd-agent-omnibus/blob/master/release.json)
+by setting the environment variable `RELEASE_VERSION`.
+
+## Local overwrite
+
+You can overwrite the following variables by setting them manually in
+`attributes.json` (useful for local dev):
+
+- dd-agent-omnibus_branch    : git version of `dd-agent-omnibus` to use
+- dd-agent_branch            : git version of `dd-agent` repo to use
+- omnibus-ruby_branch        : git version of `omnibus-ruby` to use (DataDog fork)
+- omnibus-software_branch    : git version of `omnibus-software` to use (DataDog fork)
+- integrations-core_branch   : git version of `integrations-core` to use
+- trace-agent_branch         : git version of `trace-agent` to use
+- agent_version              : The agent version targeted
+- agent6_branch              : git revision of `datadog-agent` repo to use (for dogstatsd 6)
+- trace_agent_add_build_vars :
+- process_agent_branch       : The version of the process agent to ship
+
+Variables are first loaded from the release.json and then overwritten by `attributes.json`.
+
+example of attributes.json:
+
+```json
+{
+  "dd-agent-builder": {
+    "dd-agent-omnibus_branch": "master",
+    "dd-agent_branch": "5.21.0",
+    "omnibus-ruby_branch": "master",
+    "omnibus-software_branch": "master",
+    "integrations-core_branch": "custom-postgres-branch",
+    "trace-agent_branch": "master"
+  },
+  "omnibus": {
+  }
+}
+```

--- a/attributes.json
+++ b/attributes.json
@@ -1,6 +1,5 @@
 {
   "dd-agent-builder": {
-      "omnibus-ruby_branch": "datadog-5.5.0"
   },
   "omnibus": {
   }

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -4,14 +4,9 @@ raise 'BUILD_USER_PASSWORD not set!' unless ENV['BUILD_USER_PASSWORD']
 default['omnibus']['build_user_password'] = "#{ENV['BUILD_USER_PASSWORD']}"
 
 default['dd-agent-builder']['install_dir'] = 'C:\opt\datadog-agent'
-default['dd-agent-builder']['dd-agent_branch'] = ENV['DD_AGENT_BRANCH'] || 'master'
 default['dd-agent-builder']['dd-agent-omnibus_branch'] = ENV['DD_AGENT_OMNIBUS_BRANCH'] || 'master'
-default['dd-agent-builder']['omnibus-software_branch'] = ENV['OMNIBUS_SOFTWARE_BRANCH'] || 'master'
-default['dd-agent-builder']['omnibus-ruby_branch'] = ENV['OMNIBUS_RUBY_BRANCH'] || 'datadog-5.5.0'
-default['dd-agent-builder']['integrations-core_branch'] = ENV['INTEGRATIONS_CORE_BRANCH'] || 'master'
-default['dd-agent-builder']['trace-agent_branch'] = ENV['TRACE_AGENT_BRANCH'] || 'master'
+default['dd-agent-builder']['release_version'] = ENV["RELEASE_VERSION"] || "nightly"
 
-default['dd-agent-builder']['jmx-fetch_version'] = ENV['JMX_VERSION'] || '0.14.0'
 default['dd-agent-builder']['go']['version'] = '1.6.4'
 # Values are 386 or amd64
 default['dd-agent-builder']['go']['platform'] = 'amd64'


### PR DESCRIPTION
This avoid duplicating the information in two places

I use this documentation: https://docs.chef.io/resource_ruby_block.html (section "Set environment variables")

Right now we can set `RELEASE_VERSION` in the attributes.json. For me, the next step would be to start the gitlab pipeline from jenkins (most likely in the same job where we start the circleci build for linux).